### PR TITLE
Resolve .all with array of results of original promises

### DIFF
--- a/QuickPromise/combinator.js
+++ b/QuickPromise/combinator.js
@@ -42,7 +42,7 @@ Combinator.prototype._addPromise = function(promise) {
         if (promise.isRejected) {
             this._reject(promise._result);
         }
-        // calling `resolve` after adding resolved promises is covered 
+        // calling `resolve` after adding resolved promises is covered
         // by the call to `_settle` in constructor
     } else {
         this._addCheckedPromise(promise);

--- a/tests/unittests/tst_aplus_spec.qml
+++ b/tests/unittests/tst_aplus_spec.qml
@@ -178,16 +178,17 @@ TestCase {
 
         var allPromise = Q.all([promise1,promise2,promise3]);
         compare(allPromise.state ,"pending");
-        promise1.resolve("a");
+        promise2.resolve("b"); // resolve out of order
         tick();
         compare(allPromise.state ,"pending");
-        promise2.resolve("b");
+        promise1.resolve("a");
         tick();
         compare(allPromise.state ,"pending");
         promise3.resolve("c");
         tick();
         compare(allPromise.state ,"fulfilled");
-        compare(allPromise._result,"c");
+        // results should keep original order regardless of resolution order
+        compare(allPromise._result, ["a", "b", "c"]);
 
         // Condition 2. Reject one of the promise
         promise1 = Q.promise();
@@ -218,13 +219,14 @@ TestCase {
         promise2 = Q.promise();
         promise3 = Q.promise();
 
-        promise1.resolve();
-        promise2.resolve();
-        promise3.resolve();
+        promise2.resolve('y');
+        promise1.resolve('x');
+        promise3.resolve('z');
 
         allPromise = Q.all([promise1,promise2,promise3]);
         tick();
         compare(allPromise.state ,"fulfilled");
+        compare(allPromise._result, ["x", "y", "z"]);
     }
 
     function test_q_allSettled() {
@@ -235,16 +237,17 @@ TestCase {
 
         var allPromise = Q.allSettled([promise1,promise2,promise3]);
         compare(allPromise.state ,"pending");
+        promise3.resolve("c"); // resolve out of order
+        tick();
+        compare(allPromise.state ,"pending");
         promise1.resolve("a");
         tick();
         compare(allPromise.state ,"pending");
         promise2.resolve("b");
         tick();
-        compare(allPromise.state ,"pending");
-        promise3.resolve("c");
-        tick();
         compare(allPromise.state ,"fulfilled");
-        compare(allPromise._result,"c");
+        // results should keep original order regardless of resolution order
+        compare(allPromise._result, ["a", "b", "c"]);
 
         // Condition 2. Reject one of the promise
         promise1 = Q.promise();
@@ -286,13 +289,14 @@ TestCase {
         promise2 = Q.promise();
         promise3 = Q.promise();
 
-        promise1.resolve();
-        promise2.resolve();
-        promise3.resolve();
+        promise2.resolve('y');
+        promise1.resolve('x');
+        promise3.resolve('z');
 
         allPromise = Q.allSettled([promise1,promise2,promise3]);
         tick();
         compare(allPromise.state ,"fulfilled");
+        compare(allPromise._result, ["x", "y", "z"]);
     }
 
     Component {


### PR DESCRIPTION
I've noticed that `.all` gets resolved using the last promise's results. AFAIK, it should resolve with list of results of original promises.

Feel free to make changes and/or add more test cases.
