### PR TITLE
Add convenience methods to Q

### DIFF
--- a/QuickPromise/Q.qml
+++ b/QuickPromise/Q.qml
@@ -15,6 +15,18 @@ QtObject {
         return PromiseJS.promise();
     }
 
+    function resolved(result) {
+        var p = PromiseJS.promise();
+        p.resolve(result);
+        return p;
+    }
+
+    function rejected(reason) {
+        var p = PromiseJS.promise();
+        p.reject(reason);
+        return p;
+    }
+
     function all(promises) {
         return Combinator.all(promises);
     }

--- a/tests/unittests/tst_promise_resolved_rejected.qml
+++ b/tests/unittests/tst_promise_resolved_rejected.qml
@@ -1,0 +1,30 @@
+import QtQuick 2.0
+import QtTest 1.0
+import QuickPromise 1.0
+
+TestCase {
+    name : "Promise_Resolved_Rejected"
+
+    function test_resolved() {
+        var promise = Q.resolved("blue");
+        wait(50);
+        compare(promise.hasOwnProperty("___promiseSignature___"), true);
+        compare(promise.isSettled, true);
+        compare(promise.isFulfilled, true);
+        compare(promise.isRejected, false);
+        compare(promise._result, "blue");
+    }
+
+    function test_rejected() {
+        var promise = Q.rejected("blue");
+        wait(50);
+        compare(promise.hasOwnProperty("___promiseSignature___"), true);
+        compare(promise.isSettled, true);
+        compare(promise.isFulfilled, false);
+        compare(promise.isRejected, true);
+        compare(promise._result, "blue");
+    }
+
+
+}
+


### PR DESCRIPTION
- Q.resolved(result) returns an already-resolved promise with the
  provided result
- Q.rejected(reason) returns an already-rejected promise with the
  provided reason

Also add test cases verifying that these methods work as expected.
